### PR TITLE
BRK and RTI instructions

### DIFF
--- a/emulator/src/address_bus.rs
+++ b/emulator/src/address_bus.rs
@@ -6,12 +6,6 @@ pub trait AddressBus {
     fn fetch_word_at_pc(&mut self, mem: &mut dyn MemoryAccess) -> Result<u16, CpuError>;
     fn set_pc(&mut self, address: u16) -> Result<(), CpuError>;
     fn get_pc(&self) -> u16;
-    fn load_program(
-        &mut self,
-        mem: &mut dyn MemoryAccess,
-        start_addr: u16,
-        program: &[u8],
-    ) -> Result<(), CpuError>;
 }
 
 #[derive(Clone)]
@@ -49,16 +43,6 @@ impl AddressBus for AddressBusImpl {
 
     fn get_pc(&self) -> u16 {
         self.pc
-    }
-
-    fn load_program(
-        &mut self,
-        mem: &mut dyn MemoryAccess,
-        start_addr: u16,
-        program: &[u8],
-    ) -> Result<(), CpuError> {
-        mem.load_program(start_addr, program)?;
-        Ok(())
     }
 }
 impl std::fmt::Debug for dyn AddressBus {

--- a/emulator/src/cpu.rs
+++ b/emulator/src/cpu.rs
@@ -50,7 +50,6 @@ impl CpuController for Cpu {
     }
 
     fn run(&mut self, start_addr: Option<u16>) -> Result<CpuRegisterSnapshot, CpuError> {
-        self.stack.push_word(&mut self.memory, 12)?; // TODO remove
         self.address_bus.set_pc(0x0300)?;
         if start_addr.is_some() {
             self.address_bus.set_pc(start_addr.unwrap())?;
@@ -76,8 +75,7 @@ impl CpuController for Cpu {
 
     fn load_program(&mut self, start_addr: u16, program: &[u8]) -> Result<(), CpuError> {
         self.program_loaded = true;
-        self.address_bus
-            .load_program(&mut self.memory, start_addr, program)
+        self.memory.load_program(start_addr, program)
     }
 
     fn get_register_snapshot(&self) -> crate::CpuRegisterSnapshot {

--- a/emulator/src/engine/ops/interrupt.rs
+++ b/emulator/src/engine/ops/interrupt.rs
@@ -1,8 +1,79 @@
+use crate::address_bus::AddressBus;
 use crate::cpu::{AddressingMode, Cpu};
+use crate::stack_pointer::StackPointer;
+// use crate::status_register::StatusRegister;
 use crate::CpuError;
 
-pub fn execute_brk(_: AddressingMode, cpu: &mut Cpu) -> Result<(), CpuError> {
-    cpu.status.set_break(true);
-    // TODO: push PC and status to stack, like an IRQ
+// BRK:    Force break
+// status: NV ...ZC
+pub fn execute_brk(mode: AddressingMode, cpu: &mut Cpu) -> Result<(), CpuError> {
+    if mode != AddressingMode::Implied {
+        return Err(CpuError::InvalidAddressingMode);
+    }
+    // see 6502 prog manual section 9.11 pg 144:
+    // the pushed PC skips the byte after the BRK instruction
+    let pc = cpu.address_bus.get_pc().wrapping_add(1);
+    cpu.stack.push_word(&mut cpu.memory, pc)?;
+    let status = cpu.status.get_status();
+    // set Break flag on pushed status value only
+    cpu.stack.push_byte(&mut cpu.memory, status | 0b0001_0000)?;
+
+    // HACK: set Break flag on CPU status register as well for Cpu.run() to stop on BRK
+    cpu.status.set_break_command(true);
+
+    // TODO: continue on IRQ vector: 0xFFFE
+    // cpu.address_bus.set_pc(0xFFFE)?;
     Ok(())
+}
+
+// RTI:    Return from interrupt
+// pull PC, add 1, put result in PC
+// status: NV bD.ZC
+#[allow(dead_code)] // TODO remove
+pub fn execute_rti(mode: AddressingMode, cpu: &mut Cpu) -> Result<(), CpuError> {
+    if mode != AddressingMode::Implied {
+        return Err(CpuError::InvalidAddressingMode);
+    }
+    let status = cpu.stack.pop_byte(&cpu.memory)?;
+    let pc = cpu.stack.pop_word(&cpu.memory)?;
+    cpu.status.set_status(status & 0xCF); // ignore Break and undefined flags
+    cpu.address_bus.set_pc(pc)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn brk() -> Result<(), CpuError> {
+        // assert_eq!(cpu.address_bus.get_pc(), 0xFFFE);
+        let mut cpu = Cpu::default();
+        cpu.status.set_carry(true);
+        cpu.status.set_negative(true);
+        cpu.address_bus.set_pc(0x0123)?;
+
+        execute_brk(AddressingMode::Implied, &mut cpu)?;
+        assert_eq!(cpu.stack.pop_byte(&cpu.memory)?, 0b1001_0001);
+        assert_eq!(cpu.stack.pop_word(&cpu.memory)?, 0x0124);
+        Ok(())
+    }
+
+    #[test]
+    fn rti() -> Result<(), CpuError> {
+        let mut cpu = Cpu::default();
+        cpu.stack.push_word(&mut cpu.memory, 0x1234)?;
+        cpu.stack.push_byte(&mut cpu.memory, 0b1101_1011)?;
+
+        execute_rti(AddressingMode::Implied, &mut cpu)?;
+
+        assert_eq!(cpu.address_bus.get_pc(), 0x1234);
+        assert!(cpu.status.negative());
+        assert!(cpu.status.overflow());
+        assert!(!cpu.status.break_command()); // bit4, break, is cleared by RTI
+        assert!(cpu.status.decimal_mode());
+        assert!(cpu.status.zero());
+        assert!(cpu.status.carry());
+        Ok(())
+    }
 }


### PR DESCRIPTION
the BRK instruction is still "cheating": it does NOT set the PC yet to the 0xFFFE interrupt vector address!