### PR TITLE
Add 'r6502' executable CLI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,13 +9,13 @@
       "request": "launch",
       "name": "Debug executable 'cli'",
       "cargo": {
-        "args": ["build", "--bin=cli", "--package=cli"],
+        "args": ["build", "--package=r6502", "--bin=r6502"],
         "filter": {
-          "name": "cli",
+          "name": "r6502",
           "kind": "bin"
         }
       },
-      "args": [],
+      // "args": ["-f=tests/6502_functional_test.bin"],
       "cwd": "${workspaceFolder}"
     },
     {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,35 @@ This project is also my first foray into programming with rust; the code in this
 to get hopefully close to idiomatic rust programming.
 My notes on and sources for [the journey to rust](/docs/Learning_Rust.md).
 
+## Run via cargo
+
+```bash
+cargo run --bin r6502 -- -h
+
+A 6502 emulator written in Rust
+
+Usage: r6502.exe [OPTIONS] [COMMAND]
+
+Arguments:
+  [COMMAND]  [default: run] [possible values: run, debug]
+
+Options:
+  -f, --file <FILE>  Path to binary file to load and run
+  -h, --help         Print help
+  -V, --version      Print version
+
+```
+
+With an empty program, the reset vector 0xFFFE points to a BRK instruction,
+halting the "program" after one instruction.
+
+```bash
+cargo run --bin r6502 -- -h
+PC: FFFE: A: 00 X: 00 Y: 00 S: 00000000 SP: 01FC
+Instructions: 1 Cycles: 7 Clock speed: 1.045 MHz
+Program finished after 6 μs:
+```
+
 ## Feedback & Questions
 
 Please use the issues tracker in the home repo: <https://github.com/davidjenni/6502-emu/issues>

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,9 +1,19 @@
 [package]
-name = "cli"
+name = "r6502"
+description = "A 6502 emulator written in Rust"
+authors = ["David Jenni"]
 version = "0.1.0"
 edition = "2021"
+readme = "README.md"
+repository = "https://github.com/davidjenni/6502-emu"
+homepage = "https://github.com/davidjenni/6502-emu"
+license = "MIT"
+# license-file = "LICENSE"
+categories = ["emulator", "hardware-support"]
+keywords = ["6502", "emulator", "vintage-computers", "rust"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.4", features = ["derive", "help", "usage"] }
 mos6502-emulator = { version = "0.1.0", path = "../emulator" }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,0 +1,18 @@
+use clap::{Parser, ValueEnum};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Command {
+    Run,
+    Debug,
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct CliArgs {
+    #[arg(short, long, required = false)]
+    /// Path to binary file to load and run
+    pub file: Option<String>,
+
+    #[arg(value_enum, default_value = "run")]
+    pub command: Command,
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,59 @@
+mod args;
+
+use args::CliArgs;
+use clap::Parser;
+
+use mos6502_emulator::{create, CpuError, CpuRegisterSnapshot, CpuType};
+
 fn main() {
-    println!("Hello, world!");
+    let args = CliArgs::parse();
+
+    let outcome = match args.command {
+        args::Command::Run => run(&args),
+        args::Command::Debug => {
+            todo!("Debug mode is not implemented yet");
+        }
+    };
+    match outcome {
+        Ok(snapshot) => {
+            println!();
+            print_snapshot(snapshot);
+            println!("done.");
+        }
+        Err(e) => {
+            println!("Program finished with error: {}", e);
+        }
+    }
+}
+
+fn run(args: &CliArgs) -> Result<CpuRegisterSnapshot, CpuError> {
+    let mut cpu = create(CpuType::MOS6502)?;
+    let start_addr: Option<u16> = None;
+    if args.file.is_some() {
+        todo!("Loading binary files is not implemented yet");
+        // todo!("Assign start_addr from binary file");
+    }
+    cpu.run(start_addr)
+}
+
+fn print_snapshot(snapshot: CpuRegisterSnapshot) {
+    println!(
+        "PC: {:04X}: A: {:02X} X: {:02X} Y: {:02X} S: {:08b} SP: {:04X}",
+        snapshot.program_counter,
+        snapshot.accumulator,
+        snapshot.x_register,
+        snapshot.y_register,
+        snapshot.status,
+        snapshot.stack_pointer
+    );
+    println!(
+        "Instructions: {} Cycles: {} Clock speed: {:.3} MHz",
+        snapshot.accumulated_instructions,
+        snapshot.accumulated_cycles,
+        snapshot.approximate_clock_speed / 1_000_000.0
+    );
+    println!(
+        "Program finished after {} μs:",
+        snapshot.elapsed_time.as_micros()
+    );
 }

--- a/emulator/build.rs
+++ b/emulator/build.rs
@@ -49,7 +49,10 @@ fn main() -> io::Result<()> {
     } else {
         println!("cargo:warning=failed to read i{}", opcodes_file.display());
     }
-    writeln!(out_file, "        _ => Err(CpuError::InvalidOpcode),")?;
+    writeln!(
+        out_file,
+        "        _ => Err(CpuError::InvalidOpcode(opcode)),"
+    )?;
     out_file.write_all(b"    }\n")?;
 
     out_file.flush()?;

--- a/emulator/src/lib.rs
+++ b/emulator/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time;
+
 use crate::cpu::Cpu;
 
 mod address_bus;
@@ -12,7 +14,7 @@ pub enum CpuError {
     NotInitialized,
     InvalidAddress,
     InvalidAddressingMode,
-    InvalidOpcode,
+    InvalidOpcode(u8), // TODO: also capture PC
     MissingOperand,
     StackOverflow,
 }
@@ -25,6 +27,7 @@ pub struct CpuRegisterSnapshot {
     pub program_counter: u16,
     pub status: u8,
     // stats counters:
+    pub elapsed_time: time::Duration,
     pub accumulated_cycles: u64,
     pub accumulated_instructions: u64,
     pub approximate_clock_speed: f64,
@@ -34,6 +37,7 @@ pub trait CpuController {
     fn reset(&mut self) -> Result<(), CpuError>;
     fn load_program(&mut self, start_addr: u16, program: &[u8]) -> Result<(), CpuError>;
     fn step(&mut self) -> Result<u16, CpuError>;
+    // TODO: run/step return a Result with a CpuError AND a CpuRegisterSnapshot to convey where the error occurred
     fn run(&mut self, start_addr: Option<u16>) -> Result<CpuRegisterSnapshot, CpuError>;
     fn get_register_snapshot(&self) -> CpuRegisterSnapshot;
     fn get_byte_at(&self, address: u16) -> Result<u8, CpuError>;


### PR DESCRIPTION
it launches the CPU with an empyt/nulled out program memory. Without a start address, it commences via the RESET vector and hits a BRK at the first instruction.