### PR TITLE
feat: Handle illegal opcodes more gracefully:

### DIFF
--- a/emulator/src/disassembler.rs
+++ b/emulator/src/disassembler.rs
@@ -111,4 +111,30 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn disassemble_illegal_opcode() -> Result<(), CpuError> {
+        let mut cpu = CpuImpl::new();
+        cpu.load_program(
+            0x0600,
+            &[
+                0xA9, 0x42, // LDA #$42
+                0xFA, 0xFF, // illegal opcode
+                0x00, // BRK
+            ],
+        )?;
+
+        let (mut result, mut next_addr) = disassemble(&cpu, 0x0600)?;
+        assert_eq!(result, "0600 LDA #$42");
+        assert_eq!(next_addr, 0x0602);
+
+        (result, next_addr) = disassemble(&cpu, next_addr)?;
+        assert_eq!(result, "0602 ILL(FA)");
+        assert_eq!(next_addr, 0x0603);
+
+        (result, next_addr) = disassemble(&cpu, next_addr)?;
+        assert_eq!(result, "0603 ILL(FF)");
+        assert_eq!(next_addr, 0x0604);
+        Ok(())
+    }
 }

--- a/emulator/src/engine/opcodes.rs
+++ b/emulator/src/engine/opcodes.rs
@@ -59,10 +59,31 @@ pub enum OpCode {
     TXA, // Transfer Index X to Accumulator
     TXS, // Transfer Index X to Stack pointer
     TYA, // Transfer Index Y to Accumulator
+
+    ILL(u8), // Illegal opcode
 }
 
 impl fmt::Display for OpCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        match *self {
+            OpCode::ILL(opcode) => write!(f, "ILL({:02X})", opcode),
+            _ => fmt::Debug::fmt(self, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_print_op_code() {
+        assert_eq!(OpCode::ADC.to_string(), "ADC");
+        assert_eq!(OpCode::EOR.to_string(), "EOR");
+        assert_eq!(OpCode::JSR.to_string(), "JSR");
+        assert_eq!(OpCode::LDA.to_string(), "LDA");
+        assert_eq!(OpCode::TYA.to_string(), "TYA");
+
+        assert_eq!(OpCode::ILL(0xff).to_string(), "ILL(FF)");
     }
 }


### PR DESCRIPTION
- decode as instruction of 1 byte length, it executes as BRK instruction
- disassembler will list as "ILL(##)" pseudo-instruction with opcode as hex