### PR TITLE
feat: allow loading program into read-only memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Options:
   -s, --start-address <START_ADDRESS>
           Start address (u16) for binary to be started with; can be hex address in 0x1234 format
 
+  -r, --read-only
+          loaded binary is read-only in memory (simulate ROM)
+
   -h, --help
           Print help (see a summary with '-h')
 
@@ -76,7 +79,7 @@ Debugging with step and disassembly listing is also possible.
 
 ```bash
 cargo run --bin r6502 -- debug -b ./cli/tests/assets/euclid_gcd.prg -s 0x0200
-Loaded 476 bytes at address 0040
+Loaded 476 bytes at address 0040; read-only mem=false
 PC: 0200: A: 00 X: 00 Y: 00 S: 00000000 SP: 01FF
 (dbg)> di
   0200 LDA $40

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -38,4 +38,8 @@ pub struct CliArgs {
     #[arg(short, long, required = false, value_parser = maybe_hex::<u16>)]
     /// Start address (u16) for binary to be started with; can be hex address in 0x1234 format
     pub start_address: Option<u16>,
+
+    #[arg(short, long)]
+    /// loaded binary is read-only in memory (simulate ROM)
+    pub read_only: bool,
 }

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -204,7 +204,7 @@ mod tests {
             last_addr: None,
         };
         let mut cpu = mos6502_emulator::create_cpu(mos6502_emulator::CpuType::MOS6502)?;
-        cpu.load_program(0x0300, &[0xA9, 0x42, 0x85, 0x0F, 0x00])?;
+        cpu.load_program(0x0300, &[0xA9, 0x42, 0x85, 0x0F, 0x00], true)?;
         cpu.set_pc(0x0300)?;
         let snapshot = debugger.debug_loop(&mut cpu)?;
 
@@ -229,7 +229,7 @@ mod tests {
             last_addr: None,
         };
         let mut cpu = mos6502_emulator::create_cpu(mos6502_emulator::CpuType::MOS6502)?;
-        cpu.load_program(0x0300, &[0x00])?;
+        cpu.load_program(0x0300, &[0x00], true)?;
         cpu.set_pc(0x0300)?;
         debugger.debug_loop(&mut cpu)?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -109,9 +109,15 @@ where
                 ));
             }
             let load_addr = load_addr.unwrap();
-            cpu.load_program(load_addr, &b.data)?;
+            cpu.load_program(load_addr, &b.data, args.read_only)?;
             self.writeln(
-                format!("Loaded {} bytes at address {:04X}", b.data.len(), load_addr).as_str(),
+                format!(
+                    "Loaded {} bytes at address {:04X}; read-only mem={}",
+                    b.data.len(),
+                    load_addr,
+                    args.read_only
+                )
+                .as_str(),
             );
         } else {
             self.writeln(

--- a/emulator/src/address_bus.rs
+++ b/emulator/src/address_bus.rs
@@ -70,6 +70,7 @@ mod tests {
     use super::*;
     use mockall::predicate::*;
     use mockall::*;
+    use std::ops;
 
     mock! {
         pub _Memory {}
@@ -82,6 +83,8 @@ mod tests {
             fn get_size(&self) -> usize;
             fn load_program(&mut self, start_addr: u16, program: &[u8]) -> Result<(), CpuError>;
             fn write_zero_page_word(&mut self, address: u8, value: u16) -> Result<(), CpuError>;
+            fn add_readonly(&mut self, range: ops::Range<u16>) -> Result<(), CpuError>;
+            fn clear_readonly_ranges(&mut self);
         }
     }
     #[test]

--- a/emulator/src/cpu.rs
+++ b/emulator/src/cpu.rs
@@ -23,8 +23,13 @@ impl Cpu for CpuControllerImpl {
         self.cpu.reset()
     }
 
-    fn load_program(&mut self, start_addr: u16, program: &[u8]) -> Result<(), CpuError> {
-        self.cpu.load_program(start_addr, program)
+    fn load_program(
+        &mut self,
+        start_addr: u16,
+        program: &[u8],
+        is_readonly: bool,
+    ) -> Result<(), CpuError> {
+        self.cpu.load_program(start_addr, program, is_readonly)
     }
 
     fn set_pc(&mut self, addr: u16) -> Result<(), CpuError> {

--- a/emulator/src/cpu_impl.rs
+++ b/emulator/src/cpu_impl.rs
@@ -85,8 +85,18 @@ impl CpuImpl {
         Ok(())
     }
 
-    pub fn load_program(&mut self, start_addr: u16, program: &[u8]) -> Result<(), CpuError> {
-        self.memory.load_program(start_addr, program)
+    pub fn load_program(
+        &mut self,
+        start_addr: u16,
+        program: &[u8],
+        is_readonly: bool,
+    ) -> Result<(), CpuError> {
+        self.memory.load_program(start_addr, program)?;
+        if is_readonly {
+            self.memory
+                .add_readonly(start_addr..start_addr + program.len() as u16)?;
+        }
+        Ok(())
     }
 
     pub fn set_pc(&mut self, addr: u16) -> Result<(), CpuError> {
@@ -238,7 +248,7 @@ mod tests {
     fn setup_test_cpu(program: &[u8]) -> Result<CpuImpl, CpuError> {
         let mut cpu = CpuImpl::default();
 
-        cpu.load_program(START_ADDR, program)?;
+        cpu.load_program(START_ADDR, program, false)?;
         cpu.address_bus.set_pc(START_ADDR)?;
 
         // prepare PC to point past the opcode:

--- a/emulator/src/disassembler.rs
+++ b/emulator/src/disassembler.rs
@@ -83,6 +83,7 @@ mod tests {
                 0xEA, // NOP
                 0x00, // BRK
             ],
+            true,
         )?;
 
         let (mut result, mut next_addr) = disassemble(&cpu, 0x0600)?;
@@ -122,6 +123,7 @@ mod tests {
                 0xFA, 0xFF, // illegal opcode
                 0x00, // BRK
             ],
+            true,
         )?;
 
         let (mut result, mut next_addr) = disassemble(&cpu, 0x0600)?;

--- a/emulator/src/engine/ops/alu.rs
+++ b/emulator/src/engine/ops/alu.rs
@@ -1,6 +1,8 @@
 use crate::cpu_impl::{AddressingMode, CpuImpl};
 use crate::CpuError;
 
+use super::transfer::memory_write_tolerate_readonly;
+
 // Arithmetic operations:
 
 // ADC:    A + M + C -> A, C
@@ -230,6 +232,7 @@ fn read_modify_write(
         cpu.accumulator = result;
     } else {
         cpu.memory.write(address.unwrap(), result)?;
+        memory_write_tolerate_readonly(address.unwrap(), result, cpu)?;
     }
 
     Ok(())

--- a/emulator/src/lib.rs
+++ b/emulator/src/lib.rs
@@ -27,6 +27,8 @@ pub enum CpuError {
     MissingOperand,
     #[error("op code instruction expects an operand, but none was found")]
     StackOverflow,
+    #[error("memory range is read-only")]
+    ReadOnlyMemory,
 }
 
 #[derive(Debug, Clone)]
@@ -46,7 +48,12 @@ pub struct CpuRegisterSnapshot {
 
 pub trait Cpu {
     fn reset(&mut self) -> Result<(), CpuError>;
-    fn load_program(&mut self, start_addr: u16, program: &[u8]) -> Result<(), CpuError>;
+    fn load_program(
+        &mut self,
+        start_addr: u16,
+        program: &[u8],
+        is_readonly: bool,
+    ) -> Result<(), CpuError>;
 
     // debugger API:
     fn set_pc(&mut self, addr: u16) -> Result<(), CpuError>;

--- a/emulator/src/stack_pointer.rs
+++ b/emulator/src/stack_pointer.rs
@@ -106,6 +106,7 @@ mod tests {
     use super::*;
     use mockall::predicate::*;
     use mockall::*;
+    use std::ops;
 
     mock! {
         pub _Memory {}
@@ -118,6 +119,8 @@ mod tests {
             fn get_size(&self) -> usize;
             fn load_program(&mut self, start_addr: u16, program: &[u8]) -> Result<(), CpuError>;
             fn write_zero_page_word(&mut self, address: u8, value: u16) -> Result<(), CpuError>;
+            fn add_readonly(&mut self, range: ops::Range<u16>) -> Result<(), CpuError>;
+            fn clear_readonly_ranges(&mut self);
         }
     }
 

--- a/emulator/tests/cpu_api_tests.rs
+++ b/emulator/tests/cpu_api_tests.rs
@@ -17,7 +17,8 @@ fn run_simple_program() -> Result<(), CpuError> {
                 0xA9, 0x42, // LDA #$42
                 0x85, 0x0F, // STA $0F
                 0x00, 0x00, // BRK
-            ]
+            ],
+            true
         )
         .is_ok());
     let snapshot = cpu.run(Some(0x0600))?;

--- a/emulator/tests/euclid_tests.rs
+++ b/emulator/tests/euclid_tests.rs
@@ -23,6 +23,7 @@ fn run_gcd_euclid() -> Result<(), CpuError> {
             0xA5, 0x40, // LDA VAR_A
             0x00, // BRK
         ],
+        true,
     )?;
     // initialize zero page variables:
     cpu.set_byte_at(0x0040, 126)?; // VAR_A


### PR DESCRIPTION
simulate ROM, e.g. for MSBASIC's RAM size algo that destructively writes into memory until ROM is reached.